### PR TITLE
Modify test results handling in dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -114,7 +114,7 @@ jobs:
                 --collect:"XPlat Code Coverage" \
                 --logger "trx;LogFileName=${name}.trx" \
                 --logger "junit;LogFileName=${name}.coverage.opencover.xml" \
-                --results-directory "test-results" 2>&1 | tee "test-results/${name}.log"
+                --results-directory "test-results" 2>&1 | tee "test-results/${name}.trx"
               rc=$?
               set -e
               if [ "$rc" -ne 0 ]; then
@@ -141,13 +141,6 @@ jobs:
         with:
           name: Solution-Test-Results
           path: ${{ github.workspace }}/test-results/**/*.trx
-
-      - name: Upload Test Logs
-        uses: actions/upload-artifact@v4
-        if: steps.check-tests.outputs.has_tests == 'true'
-        with:
-          name: Test-Logs
-          path: ${{ github.workspace }}/test-results/**/*.log
 
       - name: Codecov
         uses: codecov/codecov-action@v5.5.1


### PR DESCRIPTION
This pull request makes a small update to the test results handling in the `.github/workflows/dotnet.yml` workflow. The main change is to the naming and management of test log files generated during the workflow.

- The output file for test logs is now named with a `.trx` extension instead of `.log`, aligning it with the test result format.
- The step that uploads test log files as artifacts has been removed, streamlining the workflow and eliminating redundant artifact uploads.Updated the results directory for test logs and removed the upload step for test logs.