### PR TITLE
Add write permissions for issues in workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,6 +4,7 @@
 name: Build and Test .NET projects
 
 permissions:
+  issues: write
   checks: write
   contents: read
 


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow permissions for the `.NET` build and test pipeline. The change grants write access to issues, which may be needed for automation tasks that interact with GitHub issues.

* Workflow permissions: Added `issues: write` to the permissions block in `.github/workflows/dotnet.yml` to allow the workflow to write to GitHub issues.