### PR TITLE
Change default BaseUrl to use HTTPS and new port

### DIFF
--- a/e2e/Web.Tests.Playwright/Fixtures/PlaywrightTestBase.cs
+++ b/e2e/Web.Tests.Playwright/Fixtures/PlaywrightTestBase.cs
@@ -18,7 +18,7 @@ public class PlaywrightTestBase : IAsyncLifetime
 	/// <summary>
 	/// Gets the base URL for tests from environment variable or uses default
 	/// </summary>
-	protected string BaseUrl => Environment.GetEnvironmentVariable("BASE_URL") ?? "http://localhost:5057";
+	protected string BaseUrl => Environment.GetEnvironmentVariable("BASE_URL") ?? "https://localhost:7241";
 
 	/// <summary>
 	/// Cached result of server availability check to avoid multiple checks


### PR DESCRIPTION
This pull request updates the base URL used by Playwright end-to-end tests to point to the HTTPS endpoint instead of the previous HTTP endpoint. This ensures that tests run against the secure server configuration.

Test configuration update:

* Changed the default value of the `BaseUrl` property in `PlaywrightTestBase` to use `https://localhost:7241` instead of `http://localhost:5057`, improving test coverage for HTTPS scenarios.