### PR TITLE
feat: split ThemeSelector into nav-ready brightness toggle and colour dropdown

### DIFF
--- a/.squad/agents/pippin/charter.md
+++ b/.squad/agents/pippin/charter.md
@@ -1,0 +1,30 @@
+# Pippin — Blog Post Expert
+
+## Role
+Blog post and article content specialist. Owns content strategy, article feature design,
+SEO metadata, content workflows, and blog-specific functionality for the ArticlesSite.
+
+## Model
+Preferred: claude-haiku-4.5
+
+## Responsibilities
+- Article content creation guidance and feature design
+- Blog post workflow recommendations (draft, review, publish lifecycle)
+- SEO metadata and article discoverability
+- Content seeding and fake article data (FakeArticle factories)
+- Category and tagging system design
+- Article feature specifications for Hudson (backend) and Legolas (frontend)
+- Blog content documentation and editorial guidelines
+
+## Boundaries
+- Does not own backend implementation (delegates to Sam)
+- Does not own UI implementation (delegates to Legolas)
+- Does not own XML docs or README (delegates to Frodo)
+- Focuses on content strategy, feature design, and content-facing specifications
+
+## Key Domain Context
+- Articles site: ArticlesSite (TailwindBlogApp)
+- Entities: Article, Category
+- Fake data: FakeArticle.GetNewArticle(), FakeArticle.GetArticles(n, useSeed: true)
+- Seed constant: 621
+- Article DTO: ArticleDto in Web/Components/Features/Articles/Models/

--- a/.squad/agents/pippin/history.md
+++ b/.squad/agents/pippin/history.md
@@ -1,0 +1,35 @@
+# Pippin — History
+
+## Project Context
+
+**Project:** ArticlesSite (TailwindBlogApp solution)
+**User:** Matthew (mpaulosky)
+**Date Joined:** 2026-03-26
+
+### Tech Stack
+- .NET 10 / C# 14, Blazor Server, MongoDB, Redis, .NET Aspire, Auth0
+- xUnit, FluentAssertions, NSubstitute, bUnit, TestContainers
+- Vertical Slice Architecture, CQRS (static outer class), Result&lt;T&gt;
+
+### My Domain
+Blog posts and article content for the ArticlesSite — a Blazor Server app that
+manages articles and categories backed by MongoDB.
+
+### Key Paths
+- `src/Web/Components/Features/Articles/` — article feature vertical slice
+- `src/Web/Components/Features/Categories/` — category feature
+- `src/Web/Components/Features/Articles/Fakes/` — FakeArticle (Bogus, seed=621)
+- `src/Web/Components/Features/Categories/Fakes/` — FakeCategory
+
+### Key Entities
+- `Article` — title, content, author, category, published state, timestamps
+- `Category` — name, description
+- `ArticleDto` / `CategoryDto` — transfer objects used in handlers and components
+
+### Conventions
+- File copyright headers required
+- File-scoped namespaces
+- Async suffix on async methods
+- useSeed: true for deterministic test data
+
+## Learnings

--- a/.squad/casting/registry.json
+++ b/.squad/casting/registry.json
@@ -58,6 +58,14 @@
       "status": "active"
     },
     {
+      "persistent_name": "Pippin",
+      "role": "Blog Post Expert",
+      "universe": "Lord of the Rings",
+      "created_at": "2026-03-26T00:00:00Z",
+      "legacy_named": false,
+      "status": "active"
+    },
+    {
       "persistent_name": "Scribe",
       "role": "Scribe",
       "universe": "exempt",

--- a/.squad/decisions/inbox/squad-build-test-fixes-2026-03-26.md
+++ b/.squad/decisions/inbox/squad-build-test-fixes-2026-03-26.md
@@ -1,0 +1,14 @@
+## 2026-03-26: ServiceDefaults must not reference AppHost packages
+**By:** Matthew (mpaulosky) — resolved by Squad
+**What:** `src/ServiceDefaults/ServiceDefaults.csproj` MUST NOT reference `Aspire.Hosting.AppHost`, `Aspire.Hosting.MongoDB`, or `Aspire.Hosting.Redis`. These are AppHost SDK concerns only. ServiceDefaults is a shared telemetry/health library — it only needs standard Microsoft.Extensions.* packages.
+**Why:** These incorrect references caused NU1605 package downgrade conflicts (MongoDB.Driver 3.5.2 vs required 3.6.0, StackExchange.Redis 2.10.1 vs required 2.11.0) and a NU1010 error for the non-existent `Aspire.Hosting.AppHost` NuGet package.
+
+## 2026-03-26: Architecture test allowedComponentNames must be kept current
+**By:** Matthew (mpaulosky) — resolved by Squad
+**What:** When a new Razor component with `Component` suffix is added to `Web.Components`, it MUST be added to `allowedComponentNames` in `Architecture.Tests/NamingConventionTests.cs`. Otherwise the architecture test fails.
+**Why:** Added `RecentComponent` to allowed list after it was added to `Web.Components` without updating the test.
+
+## 2026-03-26: Article loading and logging moved from Home to RecentComponent
+**By:** Matthew (mpaulosky) — resolved by Squad
+**What:** `Home.razor` no longer handles article loading or logging. This was moved to `RecentComponent`. Tests that verify article loading behavior (logging on failure/error) must test `RecentComponent`'s `ILogger<RecentComponent>`, not `ILogger<Home>`.
+**Why:** Fixes `HomePage_LogsWarning_WhenHandlerFails` and `HomePage_LogsError_WhenHandlerThrows` which were checking the wrong logger type.

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -8,8 +8,9 @@
 | Blazor, Razor, UI, frontend, components, CSS | Legolas | Frontend |
 | MongoDB, repositories, API endpoints, backend services, MediatR handlers | Sam | Backend |
 | Tests, quality, edge cases, test failures, test review | Gimli | Tester |
-| CI/CD, GitHub Actions, NuGet, deployment, Aspire infra, protected branch | Boromir | DevOps |
+| CI/CD, GitHub Actions, NuGet, deployment, Aspire infra, protected branch, pipelines, builds | Boromir | CI/CD Expert |
 | Docs, README, XML docs, comments, CONTRIBUTING | Frodo | Docs |
+| Blog posts, article content, content strategy, SEO, article features, content workflows | Pippin | Blog Post Expert |
 | Auth0, authentication, authorization, JWT, RBAC, security audit, vulnerabilities, injection, XSS, CSRF, secrets, HTTPS, CORS, security headers, security review | Gandalf | Security |
 | GitHub board, issues, PRs, backlog, work queue | Ralph | Work Monitor |
 | Untriaged issues (squad label, no squad:* sub-label) | Aragorn | Lead triages |
@@ -19,6 +20,7 @@
 | squad:gimli | Gimli | — |
 | squad:boromir | Boromir | — |
 | squad:frodo | Frodo | — |
+| squad:pippin | Pippin | — |
 | squad:gandalf | Gandalf | — |
 | squad:copilot | @copilot | Auto-assign: false |
 

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -17,8 +17,9 @@
 | Legolas | Frontend Dev | squad:legolas | ⚛️ Frontend |
 | Sam | Backend Dev | squad:sam | 🔧 Backend |
 | Gimli | Tester | squad:gimli | 🧪 Tester |
-| Boromir | DevOps | squad:boromir | ⚙️ DevOps |
+| Boromir | CI/CD Expert | squad:boromir | ⚙️ DevOps |
 | Frodo | Tech Writer | squad:frodo | 📝 Docs |
+| Pippin | Blog Post Expert | squad:pippin | 📰 Content |
 | Gandalf | Security Officer | squad:gandalf | 🔒 Security |
 | Scribe | (silent) | — | 📋 Scribe |
 | Ralph | Work Monitor | — | 🔄 Monitor |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,223 @@
+# AGENTS.md – AI Agent Guide for ArticlesSite
+
+## Quick Start
+
+```powershell
+# Run the full application (requires Docker)
+dotnet run --project src/AppHost
+
+# Run all tests
+dotnet test
+
+# Filter by category
+dotnet test --filter "FullyQualifiedName~Unit"
+dotnet test --filter "FullyQualifiedName~Integration"
+```
+
+**Integration tests require Docker** – they spin up `mongo:8.0` via TestContainers automatically.
+Web binds to `http://localhost:5057` (hardcoded in AppHost for Playwright compatibility).
+
+---
+
+## Architecture Overview
+
+```
+src/
+  AppHost/          ← .NET Aspire orchestrator (entry point for running the app)
+  ServiceDefaults/  ← Shared OpenTelemetry, health checks, resilience (AddServiceDefaults())
+  Shared/           ← Cross-project contracts: Result<T>, constants, enums, helpers
+  Web/              ← Blazor Server app (all features + data layer live here)
+    Components/Features/   ← Vertical slices (Articles, Categories, AuthorInfo)
+    Data/                  ← MongoDB context, repositories, seeder
+    Services/              ← Auth0 provider, file storage, database seeder
+    Infrastructure/        ← Concurrency policies (Polly), metrics publisher
+tests/
+  Architecture.Tests/      ← NetArchTest.Rules structural/naming enforcement
+  Web.Tests.Unit/          ← xUnit + bUnit + NSubstitute
+  Web.Tests.Integration/   ← TestContainers MongoDB (real driver, no mocks)
+  Shared.Tests.Unit/
+```
+
+There is **no separate API project at runtime** – the Web Blazor app is the only service, backed directly by MongoDB and Redis (via Aspire).
+
+---
+
+## Vertical Slice Layout
+
+Every domain feature under `src/Web/Components/Features/<Feature>/` follows this structure:
+
+```
+Articles/
+  ArticlesList/       ← CQRS handler + Razor component in one folder
+    GetArticles.cs    ← static outer class with nested IHandler + Handler
+    ArticlesList.razor
+  ArticleCreate/      ← same pattern (CreateArticle.cs + Create.razor)
+  ArticleDetails/     ← GetArticle.cs + Details.razor
+  ArticleEdit/        ← EditArticle.cs + Edit.razor
+  Entities/Article.cs
+  Extensions/ArticleMappingExtensions.cs  ← .ToDto() / .ToEntity() hand-coded mapping; no AutoMapper
+  Fakes/FakeArticle.cs      ← Bogus entity factory, seed=621
+  Fakes/FakeArticleDto.cs   ← Bogus DTO factory, same seed
+  Interfaces/IArticleRepository.cs
+  Models/ArticleDto.cs
+  Models/ConcurrencyConflictResponseDto.cs  ← returned by PUT /api/articles/{id} on 409
+  Validators/ArticleDtoValidator.cs  ← FluentValidation (DTO)
+  Validators/ArticleValidator.cs     ← FluentValidation (entity)
+```
+
+Categories follows the same structure: `CategoriesList/`, `CategoryCreate/`, `CategoryDetails/`, `CategoryEdit/`.
+
+Repositories are implemented at `src/Web/Data/Repositories/` (`ArticleRepository.cs`, `CategoryRepository.cs`) and registered via DI — the per-feature `Repositories/` subdirectory is intentionally empty.
+
+### CQRS Handler Pattern
+
+All handlers use a **static outer class with nested interface + implementation**:
+
+```csharp
+public static class GetArticles
+{
+    public interface IGetArticlesHandler { Task<Result<IEnumerable<ArticleDto>>> HandleAsync(...); }
+
+    public class Handler(IArticleRepository repository, ILogger<Handler> logger) : IGetArticlesHandler
+    { ... }
+}
+```
+
+Handlers are registered in `src/Web/Data/MongoDbServiceExtensions.cs → RegisterRepositoriesAndHandlers()`. Add new handlers there when creating a new feature.
+
+**Registered handlers (as of current codebase):**
+
+| Handler | Feature slice |
+|---|---|
+| `GetArticles.Handler` | `ArticlesList/` |
+| `GetArticle.Handler` | `ArticleDetails/` |
+| `CreateArticle.Handler` | `ArticleCreate/` |
+| `EditArticle.Handler` | `ArticleEdit/` – also receives `IAsyncPolicy<Result<Article>>` (concurrency) and `IMetricsPublisher` |
+| `GetCategories.Handler` | `CategoriesList/` |
+| `GetCategory.Handler` | `CategoryDetails/` |
+| `CreateCategory.Handler` | `CategoryCreate/` |
+| `EditCategory.Handler` | `CategoryEdit/` |
+
+Validators (`ArticleDtoValidator`, `CategoryDtoValidator`, `ArticleValidator`, `CategoryValidator`) are also registered in the same method.
+
+---
+
+## Result Pattern
+
+All operations return `Result<T>` from `Shared.Abstractions` – **not** exceptions or MediatR:
+
+```csharp
+// Success
+return Result.Ok<IEnumerable<ArticleDto>>(dtos);
+
+// Failure
+return Result.Fail<IEnumerable<ArticleDto>>("message", ResultErrorCode.NotFound);
+
+// Check
+if (result.Failure) { /* result.Error, result.ErrorCode, result.Details */ }
+```
+
+`ResultErrorCode` values: `None`, `Concurrency`, `NotFound`, `Validation`, `Conflict`.
+
+---
+
+## MongoDB Access
+
+- Uses **native MongoDB.Driver** (not EF Core) via `IMongoDbContextFactory → IMongoDbContext`.
+- Context exposes `IMongoCollection<Article> Articles`, `IMongoCollection<Category> Categories`, and `IMongoDatabase Database`.
+- Config keys (checked in order): `MongoDb:ConnectionString` → `ConnectionStrings:articlesdb` → env `MONGODB_CONNECTION_STRING`.
+- Database name: `MongoDb:Database` → `MongoDb:DatabaseName` → env `MONGODB_DATABASE_NAME` → default `"articlesdb"`.
+- In AppHost, MongoDB uses `ContainerLifetime.Persistent` with a named data volume (`mongo-server-data`), plus MongoExpress UI.
+
+---
+
+## Fake Data
+
+Use Bogus-based factories in each feature's `Fakes/` folder for test data. These live in the `Web` project and are available in tests via GlobalUsings:
+
+```csharp
+Article single = FakeArticle.GetNewArticle(useSeed: true);   // deterministic
+List<Article> list = FakeArticle.GetArticles(5, useSeed: true);
+
+ArticleDto dto = FakeArticleDto.GetNewArticleDto(useSeed: true);
+List<ArticleDto> dtos = FakeArticleDto.GetArticleDtos(5, useSeed: true);
+
+// Category equivalents: FakeCategory / FakeCategoryDto with same API
+```
+
+Seed constant is `621`. Always prefer `useSeed: true` in unit tests for determinism.
+
+---
+
+## Integration Tests
+
+Integration tests use `[Collection("MongoDb Collection")]` with `MongoDbFixture : IAsyncLifetime`, which starts a real `mongo:8.0` container via TestContainers. Always call `await _fixture.ClearCollectionsAsync()` at the start of each test to ensure isolation.
+
+```csharp
+[Collection("MongoDb Collection")]
+public class MyRepositoryTests(MongoDbFixture fixture) { ... }
+```
+
+The `tests/Web.Tests.Integration/Api/` subfolder contains `ArticleApiEndToEndTests` and `ArticleApiConcurrencyTests` which test the `PUT /api/articles/{id}` minimal API endpoint using `WebApplicationFactory<Program>` wired to the TestContainers MongoDB instance.
+
+---
+
+## Minimal API Endpoints
+
+Registered in `src/Web/Program.cs` alongside the Blazor app:
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| `PUT` | `/api/articles/{id}` | Update article; returns `ArticleDto` (200), `ConcurrencyConflictResponseDto` (409), or problem (400) |
+| `GET` | `/api/files/{fileName}` | Serve uploaded images from `wwwroot/uploads/` |
+| `GET` | `/Account/Login` | Auth0 challenge with `returnUrl` redirect |
+| `GET` | `/Account/Logout` | Auth0 + cookie sign-out |
+
+The `PUT /api/articles/{id}` endpoint delegates to `EditArticle.IEditArticleHandler`. On `ResultErrorCode.Concurrency` it returns a `ConcurrencyConflictResponseDto` that includes `ServerVersion`, `ServerArticle`, and `ChangedFields`.
+
+---
+
+## File Copyright Header (Required on every file)
+
+```csharp
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     FileName.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : ArticlesSite
+// Project Name :  Web
+// =======================================================
+```
+
+---
+
+## NuGet Package Versions
+
+All versions are centrally managed in `Directory.Packages.props` at the repo root. **Never specify a version in a `.csproj` file** – use `<PackageReference Include="..." />` only.
+
+---
+
+## Key Conventions
+
+| Convention | Detail |
+|---|---|
+| File-scoped namespaces | Always (`namespace Web.Data;`) |
+| Global usings | Each project has `GlobalUsings.cs` – add common usings there |
+| Async suffix | All async methods end in `Async` |
+| Private fields | Prefixed `_` (e.g., `_repository`) |
+| Null checks | `is null` / `is not null`, not `== null` |
+| Components | Suffix `Component`; pages suffix `Page` |
+| Constants | `UPPER_CASE` |
+| No primary constructors | Use regular constructors; handler classes may use record-style injection via `class Foo(IDep dep)` but not full primary constructor syntax for non-handlers |
+| Auth | Auth0 via `Auth0.AspNetCore.Authentication`; user identity via `ClaimTypes.NameIdentifier` or `"sub"` claim |
+| Concurrency | Polly retry policy (`ConcurrencyPolicies`) for optimistic concurrency on article updates; configured via `ConcurrencyOptions` in appsettings |
+| Type alias | `IArticleConcurrencyPolicy` = `IAsyncPolicy<Result<Article>>` – defined in `Web/GlobalUsings.cs`; use this alias in DI and tests |
+| Local storage | `Blazored.LocalStorage` (`ILocalStorageService`) registered via `builder.Services.AddBlazoredLocalStorage()` |
+| Mapping | Hand-coded extension methods in `Extensions/` (e.g., `article.ToDto()`, `dto.ToEntity()`); no AutoMapper |
+
+---
+
+## Architecture Tests
+
+`tests/Architecture.Tests/` uses `NetArchTest.Rules` to enforce naming, dependency direction, and structure. Run them before submitting any structural changes. The tests locate the solution root by walking up directories to find `ArticlesSite.slnx`.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,10 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire -->
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.0" />
     <PackageVersion Include="Aspire.Hosting" Version="9.5.2" />
-    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.1.0" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.1.0" />
+    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="9.5.2" />
     <PackageVersion Include="Aspire.MongoDB.Driver" Version="9.5.2" />
     <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="9.5.2" />

--- a/docs/plan-ThemeSelectorNavRefactor.md
+++ b/docs/plan-ThemeSelectorNavRefactor.md
@@ -1,0 +1,219 @@
+# Plan: Split ThemeSelector into Nav-Ready Components
+
+**Date:** March 26, 2026
+**Status:** ✅ Implemented
+**Scope:** `src/Web/Components/Shared/` · `src/Web/Components/Layout/` · `src/Web/wwwroot/css/input.css`
+
+---
+
+## Goal
+
+Split the existing `ThemeSelector.razor` into two compact, nav-friendly Blazor components:
+
+| New Component | Purpose | Nav placement |
+|---|---|---|
+| `ThemeBrightnessToggleComponent.razor` | Two buttons — **Light (Pastel)** / **Dark (Rich)** | Right side of nav bar |
+| `ThemeColorDropdownComponent.razor` | `<select>` dropdown — Red / Blue / Green / Yellow | Right side of nav bar |
+
+The original `ThemeSelector.razor` (full settings card on the Settings/Preferences page) is **unchanged**. Both new components share the exact same `window.ThemeManager` JS calls — no new JavaScript is required.
+
+---
+
+## Background: How the Theme System Works Today
+
+```
+localStorage["tailwind-color-theme"]  ← canonical key (theme-manager.js)
+localStorage["theme"]                 ← synced brightness key (ThemeToggle.razor.js)
+
+ThemeManager.selectColorAndUpdateUI(color)       → setColor() → setTheme() → syncUI()
+ThemeManager.selectBrightnessAndUpdateUI(mode)   → setBrightness() → setTheme() → syncUI()
+ThemeManager.syncUI()                            → updates DOM buttons with .active class
+ThemeManager.getCurrentColor()                   → returns "RED" | "BLUE" | "GREEN" | "YELLOW"
+ThemeManager.getCurrentBrightness()              → returns "light" | "dark"
+```
+
+`ThemeSelector.razor` calls these functions via `JS.InvokeVoidAsync`. The new components will use the same calls — the only difference is the HTML rendered.
+
+---
+
+## Phase 1 — Create `ThemeBrightnessToggleComponent.razor`
+
+**File:** `src/Web/Components/Shared/ThemeBrightnessToggleComponent.razor`
+
+### UI Design
+
+```
+[ ☀ Light ]  [ ◐ Dark ]
+```
+
+- Two `<button>` elements styled for compact nav use.
+- Active button highlighted with `.active` class (matches existing `.brightness-btn.active` CSS).
+- Calls `ThemeManager.selectBrightnessAndUpdateUI("light"|"dark")` on click.
+- On `OnAfterRenderAsync(firstRender)` calls `ThemeManager.syncUI()` to sync active state on load.
+
+### Component Skeleton
+
+```razor
+@inject IJSRuntime JS
+
+<div class="theme-brightness-toggle">
+    <button @onclick='() => SelectBrightness("light")' class="btn brightness-btn" id="nav-btn-light">
+        ☀ Light
+    </button>
+    <button @onclick='() => SelectBrightness("dark")' class="btn brightness-btn" id="nav-btn-dark">
+        ◐ Dark
+    </button>
+</div>
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender) { ... syncUI ... }
+    private async Task SelectBrightness(string brightness) { ... selectBrightnessAndUpdateUI ... }
+}
+```
+
+### Notes
+
+- Error handling: `TaskCanceledException` and `JSDisconnectedException` caught and swallowed (matches existing pattern).
+- No new JS needed — uses `ThemeManager` already on `window`.
+- `.active` toggling is done by `ThemeManager.syncUI()` in the browser DOM — the Blazor component does not need C# state for the active button.
+
+---
+
+## Phase 2 — Create `ThemeColorDropdownComponent.razor`
+
+**File:** `src/Web/Components/Shared/ThemeColorDropdownComponent.razor`
+
+### UI Design
+
+```
+[ Color ▼ ]   (dropdown: Red / Blue / Green / Yellow)
+```
+
+- Native `<select>` element styled to match nav colours.
+- `@onchange` calls `ThemeManager.selectColorAndUpdateUI(value)`.
+- On `OnAfterRenderAsync(firstRender)` reads current color via `ThemeManager.getCurrentColor()` and sets `_selectedColor` field to reflect the active selection.
+
+### Component Skeleton
+
+```razor
+@inject IJSRuntime JS
+
+<select class="theme-color-dropdown" @onchange="OnColorChanged">
+    <option value="RED"    selected="@(_selectedColor == "RED")">🔴 Red</option>
+    <option value="BLUE"   selected="@(_selectedColor == "BLUE")">🔵 Blue</option>
+    <option value="GREEN"  selected="@(_selectedColor == "GREEN")">🟢 Green</option>
+    <option value="YELLOW" selected="@(_selectedColor == "YELLOW")">🟡 Yellow</option>
+</select>
+
+@code {
+    private string _selectedColor = "BLUE";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _selectedColor = await JS.InvokeAsync<string>("ThemeManager.getCurrentColor");
+            StateHasChanged();
+        }
+    }
+
+    private async Task OnColorChanged(ChangeEventArgs args)
+    {
+        _selectedColor = args.Value?.ToString() ?? "BLUE";
+        await JS.InvokeVoidAsync("ThemeManager.selectColorAndUpdateUI", _selectedColor);
+    }
+}
+```
+
+---
+
+## Phase 3 — Add Nav-Compact CSS Classes
+
+**File:** `src/Web/wwwroot/css/input.css`
+
+Add to the `@layer components` block:
+
+```css
+/* Nav-compact brightness toggle */
+.theme-brightness-toggle {
+    @apply flex gap-1 items-center;
+}
+
+/* Nav-compact color dropdown */
+.theme-color-dropdown {
+    @apply text-sm font-medium rounded-full px-3 py-1.5
+    bg-theme-primary-200 dark:bg-theme-primary-800
+    text-theme-primary-800 dark:text-theme-primary-100
+    border border-theme-primary-500 dark:border-theme-primary-400
+    cursor-pointer transition-all duration-200
+    hover:bg-theme-primary-300 dark:hover:bg-theme-primary-700
+    focus:outline-none focus:ring-2 focus:ring-theme-accent-500;
+}
+```
+
+Existing `.brightness-btn` and `.brightness-btn.active` classes already handle the button states — no changes needed there.
+
+---
+
+## Phase 4 — Integrate into `NavMenuComponent.razor`
+
+**File:** `src/Web/Components/Layout/NavMenuComponent.razor`
+
+Add the two new components to the right side of the nav `<div>`:
+
+```razor
+<div class="flex items-center gap-4">
+    <!-- existing nav links -->
+    <div class="hidden space-x-2 font-medium sm:block">
+        ...
+    </div>
+    <!-- Theme controls — compact nav versions -->
+    <div class="flex items-center gap-2">
+        <ThemeBrightnessToggleComponent />
+        <ThemeColorDropdownComponent />
+    </div>
+</div>
+```
+
+---
+
+## Phase 5 — Keep ThemeSelector.razor Untouched
+
+The existing `ThemeSelector.razor` (rendered on the Settings/Preferences page as a full card) is **not modified**. It continues to use the button-grid layout with `ThemeManager.syncUI()` to keep its active states in sync.
+
+Since all components share `window.ThemeManager`, state is always consistent — changing the colour from the nav dropdown also reflects in the full ThemeSelector card when the user navigates to that page, and vice versa.
+
+---
+
+## File Change Summary
+
+| File | Action | Notes |
+|---|---|---|
+| `src/Web/Components/Shared/ThemeBrightnessToggleComponent.razor` | **Create** | Phase 1 |
+| `src/Web/Components/Shared/ThemeColorDropdownComponent.razor` | **Create** | Phase 2 |
+| `src/Web/wwwroot/css/input.css` | **Edit** — add 2 CSS classes | Phase 3 |
+| `src/Web/Components/Layout/NavMenuComponent.razor` | **Edit** — add 2 component refs | Phase 4 |
+| `src/Web/Components/Shared/ThemeSelector.razor` | **No change** | Phase 5 |
+
+---
+
+## Testing Checklist
+
+- [ ] `ThemeBrightnessToggleComponent` — Light button applies `theme-*-light` class to `<html>`; Dark applies `theme-*-dark`
+- [ ] `ThemeBrightnessToggleComponent` — Active button reflects page load state (persisted from localStorage)
+- [ ] `ThemeColorDropdownComponent` — Selecting a colour updates both `localStorage["tailwind-color-theme"]` and `<html>` class
+- [ ] `ThemeColorDropdownComponent` — Dropdown pre-selects the current active colour on load
+- [ ] Changing colour from nav dropdown is reflected in full `ThemeSelector.razor` when navigating to the settings page
+- [ ] Changing brightness from nav buttons is reflected in full `ThemeSelector.razor`
+- [ ] Existing `ThemeToggle.razor` (dark-mode toggle) continues to work without conflict
+- [ ] No layout overflow in nav bar on mobile (components hidden at small breakpoints or collapsed)
+- [ ] bUnit tests — `ThemeBrightnessToggleComponent` renders 2 buttons; `ThemeColorDropdownComponent` renders 4 options
+
+---
+
+## Confirmed Decisions
+
+1. **Mobile responsiveness:** Nav theme controls are wrapped in `hidden sm:flex` — hidden below `sm` breakpoint, matching the behaviour of the existing nav links.
+2. **Emoji in dropdown:** ✅ Emoji colour indicators used (🔴🔵🟢🟡).
+3. **Dual syncUI behaviour:** ✅ Confirmed — `ThemeManager.syncUI()` updates `.brightness-btn` elements everywhere in the DOM simultaneously (both the nav buttons and the full ThemeSelector card).
+4. **`ThemeSelector.razor` long term:** Retire the full card once `ThemeBrightnessToggleComponent` + `ThemeColorDropdownComponent` are proven to cover all use-cases.

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -1,6 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-	<Sdk Name="Aspire.AppHost.Sdk" Version="13.0.0" />
+<Project Sdk="Aspire.AppHost.Sdk/13.2.0">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -11,7 +9,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Hosting.AppHost" />
 		<PackageReference Include="Aspire.Hosting.MongoDB" />
 		<PackageReference Include="Aspire.Hosting.Redis" />
 	</ItemGroup>

--- a/src/ServiceDefaults/GlobalUsings.cs
+++ b/src/ServiceDefaults/GlobalUsings.cs
@@ -11,9 +11,6 @@
 // GlobalUsings for ServiceDefaults project
 // =======================================================
 
-// Aspire types for ServiceDefaults
-global using Aspire.Hosting;
-global using Aspire.Hosting.ApplicationModel;
 // Common ASP.NET and OpenTelemetry usings required by Extensions.cs
 global using Microsoft.AspNetCore.Builder;
 global using Microsoft.AspNetCore.Diagnostics.HealthChecks;

--- a/src/ServiceDefaults/ServiceDefaults.csproj
+++ b/src/ServiceDefaults/ServiceDefaults.csproj
@@ -11,10 +11,6 @@
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App"/>
 
-		<!-- Aspire hosting packages used by DatabaseService and RedisService -->
-		<PackageReference Include="Aspire.Hosting.AppHost"/>
-		<PackageReference Include="Aspire.Hosting.MongoDB"/>
-		<PackageReference Include="Aspire.Hosting.Redis"/>
 
 		<!-- Telemetry and extensions -->
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience"/>

--- a/src/Web/Components/Layout/NavMenuComponent.razor
+++ b/src/Web/Components/Layout/NavMenuComponent.razor
@@ -16,6 +16,10 @@
 			<a href="/contact">Contacts</a>
 			<LoginComponent />
 		</div>
+		<div class="hidden sm:flex items-center gap-2">
+			<ThemeBrightnessToggleComponent />
+			<ThemeColorDropdownComponent />
+		</div>
 	</div>
 </nav>
 

--- a/src/Web/Components/Shared/ThemeBrightnessToggleComponent.razor
+++ b/src/Web/Components/Shared/ThemeBrightnessToggleComponent.razor
@@ -1,0 +1,54 @@
+@inject IJSRuntime Js
+
+<div class="theme-brightness-toggle">
+	<button @onclick='() => SelectBrightnessAsync("light")' class="btn brightness-btn" id="nav-btn-light">
+		☀ Light
+	</button>
+	<button @onclick='() => SelectBrightnessAsync("dark")' class="btn brightness-btn" id="nav-btn-dark">
+		◐ Dark
+	</button>
+</div>
+
+@code {
+	/// <summary>
+	/// Syncs the active state of both brightness buttons with the current theme on first render.
+	/// </summary>
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (firstRender)
+		{
+			try
+			{
+				await Js.InvokeVoidAsync("ThemeManager.syncUI");
+			}
+			catch (TaskCanceledException)
+			{
+				// Ignore task cancellation if the circuit is disconnected during initialization
+			}
+			catch (JSDisconnectedException)
+			{
+				// Ignore JS disconnection if the circuit has been disconnected
+			}
+		}
+	}
+
+	/// <summary>
+	/// Applies the selected brightness ("light" or "dark") and updates all ThemeManager-managed
+	/// brightness buttons in the DOM, including those in the full ThemeSelector card.
+	/// </summary>
+	private async Task SelectBrightnessAsync(string brightness)
+	{
+		try
+		{
+			await Js.InvokeVoidAsync("ThemeManager.selectBrightnessAndUpdateUI", brightness);
+		}
+		catch (TaskCanceledException)
+		{
+			// Ignore task cancellation during brightness selection
+		}
+		catch (JSDisconnectedException)
+		{
+			// Ignore JS disconnection errors during user interaction
+		}
+	}
+}

--- a/src/Web/Components/Shared/ThemeColorDropdownComponent.razor
+++ b/src/Web/Components/Shared/ThemeColorDropdownComponent.razor
@@ -1,0 +1,57 @@
+@inject IJSRuntime Js
+
+<select class="theme-color-dropdown" value="@_selectedColor" @onchange="OnColorChangedAsync">
+	<option value="RED">🔴 Red</option>
+	<option value="BLUE">🔵 Blue</option>
+	<option value="GREEN">🟢 Green</option>
+	<option value="YELLOW">🟡 Yellow</option>
+</select>
+
+@code {
+	private string _selectedColor = "BLUE";
+
+	/// <summary>
+	/// Reads the currently active colour from ThemeManager on first render so the
+	/// dropdown reflects the persisted theme without requiring user interaction.
+	/// </summary>
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (firstRender)
+		{
+			try
+			{
+				_selectedColor = await Js.InvokeAsync<string>("ThemeManager.getCurrentColor");
+				StateHasChanged();
+			}
+			catch (TaskCanceledException)
+			{
+				// Ignore task cancellation if the circuit is disconnected during initialization
+			}
+			catch (JSDisconnectedException)
+			{
+				// Ignore JS disconnection if the circuit has been disconnected
+			}
+		}
+	}
+
+	/// <summary>
+	/// Applies the selected colour while preserving the current brightness, then
+	/// syncs all ThemeManager-managed colour buttons in the DOM.
+	/// </summary>
+	private async Task OnColorChangedAsync(ChangeEventArgs args)
+	{
+		_selectedColor = args.Value?.ToString() ?? "BLUE";
+		try
+		{
+			await Js.InvokeVoidAsync("ThemeManager.selectColorAndUpdateUI", _selectedColor);
+		}
+		catch (TaskCanceledException)
+		{
+			// Ignore task cancellation during color selection
+		}
+		catch (JSDisconnectedException)
+		{
+			// Ignore JS disconnection errors during user interaction
+		}
+	}
+}

--- a/src/Web/Data/MongoDbServiceExtensions.cs
+++ b/src/Web/Data/MongoDbServiceExtensions.cs
@@ -31,9 +31,13 @@ public static class MongoDbServiceExtensions
 		var configuration = builder.Configuration;
 
 		// Get MongoDB connection string from configuration or environment variables.
-		// Support both "MongoDb:ConnectionString" and legacy "ConnectionStrings:articlesdb" keys so tests and environments work.
-		string? connectionString = configuration["MongoDb:ConnectionString"] ?? configuration["ConnectionStrings:articlesdb"];
-		connectionString ??= Environment.GetEnvironmentVariable("MONGODB_CONNECTION_STRING");
+		// Use IsNullOrWhiteSpace so that empty strings (e.g. CI env vars like MongoDB__ConnectionString="")
+		// are treated as absent and the fallback chain continues.
+		string? connectionString = configuration["MongoDb:ConnectionString"];
+		if (string.IsNullOrWhiteSpace(connectionString))
+			connectionString = configuration["ConnectionStrings:articlesdb"];
+		if (string.IsNullOrWhiteSpace(connectionString))
+			connectionString = Environment.GetEnvironmentVariable("MONGODB_CONNECTION_STRING");
 		if (string.IsNullOrWhiteSpace(connectionString))
 		{
 			throw new InvalidOperationException("MongoDB connection string not found.");

--- a/src/Web/wwwroot/css/app.css
+++ b/src/Web/wwwroot/css/app.css
@@ -85,14 +85,11 @@
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
     --color-theme-primary-50: oklch(98.3% 0.008 264.52);
-    --color-theme-primary-100: oklch(96.1% 0.018 266.34);
-    --color-theme-primary-200: oklch(93.5% 0.035 267.89);
     --color-theme-primary-300: oklch(89.8% 0.052 269.12);
     --color-theme-primary-400: oklch(83.6% 0.095 270.22);
     --color-theme-primary-500: oklch(77.2% 0.135 271.01);
     --color-theme-primary-600: oklch(70.1% 0.156 272.45);
     --color-theme-primary-700: oklch(62.4% 0.158 273.98);
-    --color-theme-primary-800: oklch(52.3% 0.145 274.65);
     --color-theme-primary-900: oklch(42.1% 0.125 275.34);
     --color-theme-accent-100: oklch(96.8% 0.035 52.34);
     --color-theme-accent-400: oklch(90.2% 0.085 52.34);
@@ -1510,34 +1507,21 @@
     display: block;
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
-    color: var(--color-theme-primary-800);
+    color: var(--color-theme-neutral-800);
     &:where(.dark, .dark *) {
-      color: var(--color-theme-primary-100);
-    }
-  }
-  .info-label {
-    --tw-font-weight: var(--font-weight-semibold);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-theme-primary-800);
-    &:where(.dark, .dark *) {
-      color: var(--color-white);
+      color: var(--color-theme-neutral-300);
     }
   }
   .input-textbox {
     width: 100%;
-    border-radius: var(--radius-md);
+    border-radius: 0.25rem;
     border-style: var(--tw-border-style);
     border-width: 2px;
-    border-color: var(--color-theme-primary-700);
-    background-color: var(--color-theme-primary-50);
+    border-color: var(--color-theme-primary-500);
+    background-color: var(--color-theme-neutral-50);
     padding-inline: calc(var(--spacing) * 3);
     padding-block: calc(var(--spacing) * 2);
-    color: var(--color-theme-primary-900);
-    &:hover {
-      @media (hover: hover) {
-        border-color: var(--color-theme-primary-900);
-      }
-    }
+    color: var(--color-theme-neutral-900);
     &:focus {
       --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -1550,20 +1534,10 @@
       outline-style: none;
     }
     &:where(.dark, .dark *) {
-      border-color: var(--color-theme-primary-300);
-    }
-    &:where(.dark, .dark *) {
-      background-color: var(--color-theme-primary-800);
+      background-color: var(--color-theme-neutral-800);
     }
     &:where(.dark, .dark *) {
       color: var(--color-white);
-    }
-    &:where(.dark, .dark *) {
-      &:hover {
-        @media (hover: hover) {
-          border-color: var(--color-theme-primary-500);
-        }
-      }
     }
   }
   .theme-selector-container {
@@ -1773,63 +1747,6 @@
       &:hover {
         @media (hover: hover) {
           color: var(--color-theme-primary-900);
-        }
-      }
-    }
-  }
-  .theme-brightness-toggle {
-    display: flex;
-    align-items: center;
-    gap: calc(var(--spacing) * 1);
-  }
-  .theme-color-dropdown {
-    cursor: pointer;
-    border-radius: calc(infinity * 1px);
-    border-style: var(--tw-border-style);
-    border-width: 1px;
-    border-color: var(--color-theme-primary-500);
-    background-color: var(--color-theme-primary-200);
-    padding-inline: calc(var(--spacing) * 3);
-    padding-block: calc(var(--spacing) * 1.5);
-    font-size: var(--text-sm);
-    line-height: var(--tw-leading, var(--text-sm--line-height));
-    --tw-font-weight: var(--font-weight-medium);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-theme-primary-800);
-    transition-property: all;
-    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
-    transition-duration: var(--tw-duration, var(--default-transition-duration));
-    --tw-duration: 200ms;
-    transition-duration: 200ms;
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-theme-primary-300);
-      }
-    }
-    &:focus {
-      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
-      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-    }
-    &:focus {
-      --tw-ring-color: var(--color-theme-accent-500);
-    }
-    &:focus {
-      --tw-outline-style: none;
-      outline-style: none;
-    }
-    &:where(.dark, .dark *) {
-      border-color: var(--color-theme-primary-400);
-    }
-    &:where(.dark, .dark *) {
-      background-color: var(--color-theme-primary-800);
-    }
-    &:where(.dark, .dark *) {
-      color: var(--color-theme-primary-100);
-    }
-    &:where(.dark, .dark *) {
-      &:hover {
-        @media (hover: hover) {
-          background-color: var(--color-theme-primary-700);
         }
       }
     }

--- a/src/Web/wwwroot/css/app.css
+++ b/src/Web/wwwroot/css/app.css
@@ -86,6 +86,7 @@
     --default-mono-font-family: var(--font-mono);
     --color-theme-primary-50: oklch(98.3% 0.008 264.52);
     --color-theme-primary-100: oklch(96.1% 0.018 266.34);
+    --color-theme-primary-200: oklch(93.5% 0.035 267.89);
     --color-theme-primary-300: oklch(89.8% 0.052 269.12);
     --color-theme-primary-400: oklch(83.6% 0.095 270.22);
     --color-theme-primary-500: oklch(77.2% 0.135 271.01);
@@ -1043,6 +1044,11 @@
       display: block;
     }
   }
+  .sm\:flex {
+    @media (width >= 40rem) {
+      display: flex;
+    }
+  }
   .sm\:text-2xl {
     @media (width >= 40rem) {
       font-size: var(--text-2xl);
@@ -1767,6 +1773,63 @@
       &:hover {
         @media (hover: hover) {
           color: var(--color-theme-primary-900);
+        }
+      }
+    }
+  }
+  .theme-brightness-toggle {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--spacing) * 1);
+  }
+  .theme-color-dropdown {
+    cursor: pointer;
+    border-radius: calc(infinity * 1px);
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+    border-color: var(--color-theme-primary-500);
+    background-color: var(--color-theme-primary-200);
+    padding-inline: calc(var(--spacing) * 3);
+    padding-block: calc(var(--spacing) * 1.5);
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-theme-primary-800);
+    transition-property: all;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+    --tw-duration: 200ms;
+    transition-duration: 200ms;
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-theme-primary-300);
+      }
+    }
+    &:focus {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+    &:focus {
+      --tw-ring-color: var(--color-theme-accent-500);
+    }
+    &:focus {
+      --tw-outline-style: none;
+      outline-style: none;
+    }
+    &:where(.dark, .dark *) {
+      border-color: var(--color-theme-primary-400);
+    }
+    &:where(.dark, .dark *) {
+      background-color: var(--color-theme-primary-800);
+    }
+    &:where(.dark, .dark *) {
+      color: var(--color-theme-primary-100);
+    }
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: var(--color-theme-primary-700);
         }
       }
     }

--- a/src/Web/wwwroot/css/input.css
+++ b/src/Web/wwwroot/css/input.css
@@ -157,4 +157,20 @@
 		text-theme-primary-700 dark:text-theme-primary-50
 		hover:text-theme-primary-900 dark:hover:text-theme-primary-900;
 	}
+
+	/* Nav-compact brightness toggle wrapper */
+	.theme-brightness-toggle {
+		@apply flex gap-1 items-center;
+	}
+
+	/* Nav-compact color dropdown */
+	.theme-color-dropdown {
+		@apply text-sm font-medium rounded-full px-3 py-1.5
+		bg-theme-primary-200 dark:bg-theme-primary-800
+		text-theme-primary-800 dark:text-theme-primary-100
+		border border-theme-primary-500 dark:border-theme-primary-400
+		cursor-pointer transition-all duration-200
+		hover:bg-theme-primary-300 dark:hover:bg-theme-primary-700
+		focus:outline-none focus:ring-2 focus:ring-theme-accent-500;
+	}
 }

--- a/src/Web/wwwroot/css/input.css
+++ b/src/Web/wwwroot/css/input.css
@@ -44,11 +44,11 @@
 		bg-theme-primary-300 dark:bg-theme-primary-700;
 	}
 
-	.btn {
-		@apply inline-block
-		font-semibold px-5 py-2
-		rounded-full text-base
-		leading-tight border-none
+	.btn { 
+		@apply inline-block 
+		font-semibold px-5 py-2 
+		rounded-full text-base 
+		leading-tight border-none 
 		cursor-pointer transition shadow-sm;
 	}
 
@@ -74,20 +74,11 @@
 	}
 
 	.edit-label {
-		@apply block text-theme-primary-800 dark:text-theme-primary-100 font-semibold mb-2;
-	}
-
-	.info-label {
-		@apply text-theme-primary-800 dark:text-white font-semibold;
+		@apply block text-theme-neutral-800 dark:text-theme-neutral-300 font-semibold mb-2;
 	}
 
 	.input-textbox {
-		@apply border-2 px-3 py-2 rounded-md w-full
-		bg-theme-primary-50 dark:bg-theme-primary-800
-		text-theme-primary-900 dark:text-white
-		border-theme-primary-700 dark:border-theme-primary-300
-		hover:border-theme-primary-900 dark:hover:border-theme-primary-500
-		focus:outline-none focus:ring-2 focus:ring-theme-accent-500;
+		@apply bg-theme-neutral-50 dark:bg-theme-neutral-800 text-theme-neutral-900 dark:text-white border-2 border-theme-primary-500 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-theme-accent-500 w-full;
 	}
 
 	.theme-selector-container {
@@ -115,8 +106,8 @@
 	.brightness-btn {
 		@apply px-3 py-2 rounded-full font-medium text-sm transition-all duration-200
 		bg-theme-neutral-200 dark:bg-theme-neutral-700
-		hover:bg-theme-primary-300 dark:hover:bg-theme-primary-700
 		text-theme-neutral-700 dark:text-theme-neutral-300
+		hover:bg-theme-primary-300 dark:hover:bg-theme-primary-700
 		border-2 border-transparent
 		cursor-pointer;
 	}
@@ -156,21 +147,5 @@
 		@apply p-1 font-semibold
 		text-theme-primary-700 dark:text-theme-primary-50
 		hover:text-theme-primary-900 dark:hover:text-theme-primary-900;
-	}
-
-	/* Nav-compact brightness toggle wrapper */
-	.theme-brightness-toggle {
-		@apply flex gap-1 items-center;
-	}
-
-	/* Nav-compact color dropdown */
-	.theme-color-dropdown {
-		@apply text-sm font-medium rounded-full px-3 py-1.5
-		bg-theme-primary-200 dark:bg-theme-primary-800
-		text-theme-primary-800 dark:text-theme-primary-100
-		border border-theme-primary-500 dark:border-theme-primary-400
-		cursor-pointer transition-all duration-200
-		hover:bg-theme-primary-300 dark:hover:bg-theme-primary-700
-		focus:outline-none focus:ring-2 focus:ring-theme-accent-500;
 	}
 }

--- a/tests/Architecture.Tests/NamingConventionTests.cs
+++ b/tests/Architecture.Tests/NamingConventionTests.cs
@@ -131,7 +131,8 @@ public class NamingConventionTests
 				"NavMenuComponent", "ConnectWithUsComponent", "ComponentHeadingComponent", "FooterComponent",
 				"ErrorAlertComponent", "ErrorPageComponent", "LoginComponent", "PageHeaderComponent",
 				"RecentRelatedComponent", "PostInfoComponent", "LoadingComponent", "PageHeadingComponent",
-				"WelcomeComponent", "ThemeToggle", "ThemeSelector", "RedirectToLogin", "TextEditor"
+				"WelcomeComponent", "ThemeToggle", "ThemeSelector", "RedirectToLogin", "TextEditor",
+				"RecentComponent"
 		};
 
 		foreach (Type component in components)

--- a/tests/Architecture.Tests/NamingConventionTests.cs
+++ b/tests/Architecture.Tests/NamingConventionTests.cs
@@ -7,7 +7,7 @@
 // Project Name :  Architecture.Tests
 // =======================================================
 
-namespace Architecture.Tests.Unit;
+namespace Architecture.Tests;
 
 /// <summary>
 ///   Tests to validate naming conventions across the solution
@@ -126,14 +126,14 @@ public class NamingConventionTests
 				.Where(t => t.Name.EndsWith("Component"));
 
 		// Assert - Only specific shared components should have Component suffix
-		string[] allowedComponentNames = new[]
-		{
+		string[] allowedComponentNames =
+		[
 				"NavMenuComponent", "ConnectWithUsComponent", "ComponentHeadingComponent", "FooterComponent",
 				"ErrorAlertComponent", "ErrorPageComponent", "LoginComponent", "PageHeaderComponent",
 				"RecentRelatedComponent", "PostInfoComponent", "LoadingComponent", "PageHeadingComponent",
 				"WelcomeComponent", "ThemeToggle", "ThemeSelector", "RedirectToLogin", "TextEditor",
 				"RecentComponent", "ThemeBrightnessToggleComponent", "ThemeColorDropdownComponent"
-		};
+		];
 
 		foreach (Type component in components)
 		{

--- a/tests/Architecture.Tests/NamingConventionTests.cs
+++ b/tests/Architecture.Tests/NamingConventionTests.cs
@@ -132,7 +132,7 @@ public class NamingConventionTests
 				"ErrorAlertComponent", "ErrorPageComponent", "LoginComponent", "PageHeaderComponent",
 				"RecentRelatedComponent", "PostInfoComponent", "LoadingComponent", "PageHeadingComponent",
 				"WelcomeComponent", "ThemeToggle", "ThemeSelector", "RedirectToLogin", "TextEditor",
-				"RecentComponent"
+				"RecentComponent", "ThemeBrightnessToggleComponent", "ThemeColorDropdownComponent"
 		};
 
 		foreach (Type component in components)

--- a/tests/Web.Tests.Integration/Infrastructure/MongoDbFixture.cs
+++ b/tests/Web.Tests.Integration/Infrastructure/MongoDbFixture.cs
@@ -111,6 +111,8 @@ public class MongoDbFixture : IAsyncLifetime
 	/// </summary>
 	public async ValueTask DisposeAsync()
 	{
+		Environment.SetEnvironmentVariable("MONGODB_CONNECTION_STRING", null, EnvironmentVariableTarget.Process);
+		Environment.SetEnvironmentVariable("MONGODB_DATABASE_NAME", null, EnvironmentVariableTarget.Process);
 		if (_mongoDbContainer is not null)
 		{
 			await _mongoDbContainer.DisposeAsync();

--- a/tests/Web.Tests.Unit/Components/Features/Categories/CategoryDetails/DetailsComponentTests.cs
+++ b/tests/Web.Tests.Unit/Components/Features/Categories/CategoryDetails/DetailsComponentTests.cs
@@ -223,9 +223,10 @@ public class DetailsComponentTests : BunitContext
 		// Act
 		var cut = Render<Details>(parameters => parameters.Add(p => p.Id, "507f1f77bcf86cd799439011"));
 
-		cut.WaitForState(() => cut.Markup.Contains("Active"));
-		cut.Markup.Should().Contain("Status:");
-		cut.Markup.Should().Contain("Active");
+		// The component shows "Archived: False" for non-archived categories
+		cut.WaitForState(() => cut.Markup.Contains("Archived:"));
+		cut.Markup.Should().Contain("Archived:");
+		cut.Markup.Should().Contain("False");
 	}
 
 	[Fact]
@@ -254,9 +255,10 @@ public class DetailsComponentTests : BunitContext
 		// Act
 		var cut = Render<Details>(parameters => parameters.Add(p => p.Id, "507f1f77bcf86cd799439011"));
 
-		cut.WaitForState(() => cut.Markup.Contains("Archived"));
-		cut.Markup.Should().Contain("Status:");
-		cut.Markup.Should().Contain("Archived");
+		// The component shows "Archived: True" for archived categories
+		cut.WaitForState(() => cut.Markup.Contains("Archived:"));
+		cut.Markup.Should().Contain("Archived:");
+		cut.Markup.Should().Contain("True");
 	}
 
 	[Fact]

--- a/tests/Web.Tests.Unit/Components/Layout/MainLayoutTests.cs
+++ b/tests/Web.Tests.Unit/Components/Layout/MainLayoutTests.cs
@@ -127,6 +127,9 @@ public class MainLayoutComponentTests : BunitContext
 		Services.AddSingleton(authService);
 		// Register a fake authentication state provider and cascading auth state
 		Helpers.TestAuthHelper.RegisterTestAuthentication(Services, "TEST USER", [ "Admin" ]);
+		// Mock JS calls made by ThemeColorDropdownComponent and ThemeBrightnessToggleComponent in NavMenu
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+		JSInterop.SetupVoid("ThemeManager.syncUI");
 	}
 	[Fact]
 	public async Task OnAfterRender_FirstRender_SetsInitializedFlag()

--- a/tests/Web.Tests.Unit/Components/Layout/NavMenuComponentTests.cs
+++ b/tests/Web.Tests.Unit/Components/Layout/NavMenuComponentTests.cs
@@ -1,0 +1,233 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     NavMenuComponentTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : ArticlesSite
+// Project Name :  Web.Tests.Unit
+// =======================================================
+
+using Microsoft.AspNetCore.Authorization;
+
+namespace Web.Components.Layout;
+
+/// <summary>
+/// Unit tests for NavMenuComponent using bUnit.
+/// Covers integration of ThemeBrightnessToggleComponent and ThemeColorDropdownComponent
+/// inside the nav bar, including mobile-hiding behaviour.
+///
+/// Test list items covered:
+///   Item 5 — theme controls present so colour changes propagate via shared ThemeManager
+///   Item 6 — brightness toggle present so brightness changes propagate via shared ThemeManager
+///   Item 8 — nav theme controls hidden on mobile (hidden sm:flex wrapper)
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class NavMenuComponentTests : BunitContext
+{
+	public NavMenuComponentTests()
+	{
+		// Auth services required by AuthorizeView used inside the nav
+		Services.AddAuthorization();
+		Services.AddSingleton<IAuthorizationService, AlwaysAllowAuthorizationService>();
+		Services.AddSingleton<AuthenticationStateProvider>(
+			new TestAuthStateProvider(isAuthenticated: false));
+
+		// JS interop required by the two child theme components
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Test list item 8 — theme controls hidden on mobile, visible on sm+
+	// ──────────────────────────────────────────────────────────────────────────
+
+	/// <summary>
+	/// The wrapper div that holds both theme components must carry
+	/// "hidden sm:flex" so it collapses on small screens exactly like the nav links.
+	/// </summary>
+	[Fact]
+	public void NavMenu_ThemeControls_Wrapper_HasHiddenSmFlexClasses()
+	{
+		// Act
+		var cut = Render<CascadingAuthenticationState>(
+			parameters => parameters.AddChildContent<NavMenuComponent>());
+
+		// Assert
+		var themeWrapper = cut.Find(".hidden.sm\\:flex");
+		themeWrapper.Should().NotBeNull("the theme controls must be wrapped in 'hidden sm:flex' to hide on mobile");
+	}
+
+	[Fact]
+	public void NavMenu_ThemeControls_Wrapper_HasItemsCenter_And_Gap2_Classes()
+	{
+		// Act
+		var cut = Render<CascadingAuthenticationState>(
+			parameters => parameters.AddChildContent<NavMenuComponent>());
+
+		// Assert
+		var themeWrapper = cut.Find(".hidden.sm\\:flex");
+		themeWrapper.ClassList.Should().Contain("items-center");
+		themeWrapper.ClassList.Should().Contain("gap-2");
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Test list items 5 & 6 — both theme components are rendered in the nav
+	// (their presence ensures changes propagate through the shared ThemeManager)
+	// ──────────────────────────────────────────────────────────────────────────
+
+	/// <summary>
+	/// Test list item 6 — brightness toggle is rendered in the nav.
+	/// </summary>
+	[Fact]
+	public void NavMenu_Renders_ThemeBrightnessToggleComponent()
+	{
+		// Act
+		var cut = Render<CascadingAuthenticationState>(
+			parameters => parameters.AddChildContent<NavMenuComponent>());
+
+		// Assert — brightness toggle wrapper is present
+		cut.Find(".theme-brightness-toggle").Should().NotBeNull(
+			"ThemeBrightnessToggleComponent must be rendered so brightness changes sync with ThemeSelector");
+	}
+
+	/// <summary>
+	/// Test list item 5 — colour dropdown is rendered in the nav.
+	/// </summary>
+	[Fact]
+	public void NavMenu_Renders_ThemeColorDropdownComponent()
+	{
+		// Act
+		var cut = Render<CascadingAuthenticationState>(
+			parameters => parameters.AddChildContent<NavMenuComponent>());
+
+		// Assert — colour dropdown is present
+		cut.Find(".theme-color-dropdown").Should().NotBeNull(
+			"ThemeColorDropdownComponent must be rendered so colour changes sync with ThemeSelector");
+	}
+
+	[Fact]
+	public void NavMenu_Renders_BothThemeComponents_InsideTheSameWrapper()
+	{
+		// Act
+		var cut = Render<CascadingAuthenticationState>(
+			parameters => parameters.AddChildContent<NavMenuComponent>());
+
+		// Assert — both components sit within the same hidden sm:flex wrapper
+		var themeWrapper = cut.Find(".hidden.sm\\:flex");
+		themeWrapper.QuerySelector(".theme-brightness-toggle").Should().NotBeNull(
+			"brightness toggle must be inside the hidden sm:flex div");
+		themeWrapper.QuerySelector(".theme-color-dropdown").Should().NotBeNull(
+			"colour dropdown must be inside the hidden sm:flex div");
+	}
+
+	/// <summary>
+	/// Brightness toggle renders 2 buttons inside the nav.
+	/// </summary>
+	[Fact]
+	public void NavMenu_ThemeBrightnessToggle_RendersTwoButtons()
+	{
+		// Act
+		var cut = Render<CascadingAuthenticationState>(
+			parameters => parameters.AddChildContent<NavMenuComponent>());
+
+		// Assert
+		var brightnessButtons = cut.FindAll(".brightness-btn");
+		brightnessButtons.Should().HaveCount(2);
+	}
+
+	/// <summary>
+	/// Colour dropdown renders 4 options inside the nav.
+	/// </summary>
+	[Fact]
+	public void NavMenu_ThemeColorDropdown_RendersAllFourOptions()
+	{
+		// Act
+		var cut = Render<CascadingAuthenticationState>(
+			parameters => parameters.AddChildContent<NavMenuComponent>());
+
+		// Assert
+		cut.Find(".theme-color-dropdown").QuerySelectorAll("option").Should().HaveCount(4);
+	}
+
+	/// <summary>
+	/// Test list item 5 — clicking the colour dropdown calls the same JS function
+	/// that ThemeSelector uses, ensuring cross-component state sync.
+	/// </summary>
+	[Fact]
+	public async Task NavMenu_ColorDropdown_OnChange_CallsSelectColorAndUpdateUI()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.selectColorAndUpdateUI", _ => true);
+
+		var cut = Render<CascadingAuthenticationState>(
+			parameters => parameters.AddChildContent<NavMenuComponent>());
+
+		// Act
+		await cut.Find(".theme-color-dropdown").ChangeAsync(new() { Value = "RED" });
+
+		// Assert — same function ThemeSelector uses; syncUI will update .color-btn active states
+		JSInterop.VerifyInvoke("ThemeManager.selectColorAndUpdateUI");
+		JSInterop.Invocations["ThemeManager.selectColorAndUpdateUI"][0]
+			.Arguments[0].Should().Be("RED");
+	}
+
+	/// <summary>
+	/// Test list item 6 — clicking the brightness buttons calls the same JS function
+	/// that ThemeSelector uses, ensuring cross-component state sync.
+	/// </summary>
+	[Fact]
+	public async Task NavMenu_BrightnessButtons_OnClick_CallsSelectBrightnessAndUpdateUI()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.selectBrightnessAndUpdateUI", _ => true);
+
+		var cut = Render<CascadingAuthenticationState>(
+			parameters => parameters.AddChildContent<NavMenuComponent>());
+
+		// Act
+		await cut.Find("#nav-btn-dark").ClickAsync(new());
+
+		// Assert — same function ThemeSelector uses; syncUI will update .brightness-btn active states
+		JSInterop.VerifyInvoke("ThemeManager.selectBrightnessAndUpdateUI");
+		JSInterop.Invocations["ThemeManager.selectBrightnessAndUpdateUI"][0]
+			.Arguments[0].Should().Be("dark");
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Helpers
+	// ──────────────────────────────────────────────────────────────────────────
+
+	private sealed class AlwaysAllowAuthorizationService : IAuthorizationService
+	{
+		public Task<AuthorizationResult> AuthorizeAsync(
+			ClaimsPrincipal user, object? resource, IEnumerable<IAuthorizationRequirement> requirements)
+			=> Task.FromResult(
+				user.Identity?.IsAuthenticated == true
+					? AuthorizationResult.Success()
+					: AuthorizationResult.Failed());
+
+		public Task<AuthorizationResult> AuthorizeAsync(
+			ClaimsPrincipal user, object? resource, string policyName)
+			=> Task.FromResult(
+				user.Identity?.IsAuthenticated == true
+					? AuthorizationResult.Success()
+					: AuthorizationResult.Failed());
+	}
+
+	private sealed class TestAuthStateProvider : AuthenticationStateProvider
+	{
+		private readonly bool _isAuthenticated;
+
+		public TestAuthStateProvider(bool isAuthenticated) =>
+			_isAuthenticated = isAuthenticated;
+
+		public override Task<AuthenticationState> GetAuthenticationStateAsync()
+		{
+			var identity = _isAuthenticated
+				? new ClaimsIdentity([new Claim("name", "TestUser")], "TestAuth")
+				: new ClaimsIdentity();
+
+			return Task.FromResult(new AuthenticationState(new ClaimsPrincipal(identity)));
+		}
+	}
+}

--- a/tests/Web.Tests.Unit/Components/Pages/HomePageTests.cs
+++ b/tests/Web.Tests.Unit/Components/Pages/HomePageTests.cs
@@ -5,11 +5,13 @@ public class HomePageTests : BunitContext
 {
 	private readonly GetArticles.IGetArticlesHandler _articlesHandler = Substitute.For<GetArticles.IGetArticlesHandler>();
 	private readonly ILogger<Home> _logger = Substitute.For<ILogger<Home>>();
+	private readonly ILogger<RecentComponent> _recentLogger = Substitute.For<ILogger<RecentComponent>>();
 
 	public HomePageTests()
 	{
 		Services.AddSingleton(_articlesHandler);
 		Services.AddSingleton(_logger);
+		Services.AddSingleton(_recentLogger);
 	}
 
 	[Fact]
@@ -110,8 +112,8 @@ public class HomePageTests : BunitContext
 		var cut = Render<Home>();
 		await cut.InvokeAsync(() => Task.CompletedTask);
 
-		// Assert
-		_logger.Received().Log(
+		// Assert - RecentComponent owns article loading and logging since Home delegates to it
+		_recentLogger.Received().Log(
 			LogLevel.Warning,
 			Arg.Any<EventId>(),
 			Arg.Any<object>(),
@@ -124,7 +126,7 @@ public class HomePageTests : BunitContext
 	public async Task HomePage_LogsError_WhenHandlerThrows()
 	{
 		// Arrange
-		_articlesHandler.HandleAsync(  )
+		_articlesHandler.HandleAsync()
 			.Returns(_ => Task.FromException<Result<IEnumerable<ArticleDto>>>(new Exception("fail")));
 
 		// Setup JSInterop for ThemeManager.syncUI
@@ -134,8 +136,8 @@ public class HomePageTests : BunitContext
 		var cut = Render<Home>();
 		await cut.InvokeAsync(() => Task.CompletedTask);
 
-		// Assert
-		_logger.Received().Log(
+		// Assert - RecentComponent owns article loading and logging since Home delegates to it
+		_recentLogger.Received().Log(
 			LogLevel.Error,
 			Arg.Any<EventId>(),
 			Arg.Any<object>(),

--- a/tests/Web.Tests.Unit/Components/Shared/ThemeBrightnessToggleComponentTests.cs
+++ b/tests/Web.Tests.Unit/Components/Shared/ThemeBrightnessToggleComponentTests.cs
@@ -1,0 +1,259 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     ThemeBrightnessToggleComponentTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : ArticlesSite
+// Project Name :  Web.Tests.Unit
+// =======================================================
+
+namespace Web.Components.Shared;
+
+/// <summary>
+/// Unit tests for ThemeBrightnessToggleComponent using bUnit.
+/// Covers rendering, first-render sync, button clicks, and JS interop argument verification.
+///
+/// JS-side effects (HTML class application) are verified by asserting the exact arguments
+/// passed to ThemeManager.selectBrightnessAndUpdateUI / ThemeManager.syncUI,
+/// because bUnit does not execute real JavaScript.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class ThemeBrightnessToggleComponentTests : BunitContext
+{
+	// ──────────────────────────────────────────────────────────────────────────
+	// Rendering
+	// ──────────────────────────────────────────────────────────────────────────
+
+	/// <summary>
+	/// Test list item 9 — component renders exactly 2 brightness buttons.
+	/// </summary>
+	[Fact]
+	public void ThemeBrightnessToggle_Renders_ExactlyTwoButtons()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+
+		// Act
+		var cut = Render<ThemeBrightnessToggleComponent>();
+
+		// Assert
+		cut.FindAll("button").Should().HaveCount(2);
+	}
+
+	[Fact]
+	public void ThemeBrightnessToggle_Renders_LightButton()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+
+		// Act
+		var cut = Render<ThemeBrightnessToggleComponent>();
+
+		// Assert
+		var lightBtn = cut.Find("#nav-btn-light");
+		lightBtn.Should().NotBeNull();
+		lightBtn.TextContent.Trim().Should().Contain("Light");
+	}
+
+	[Fact]
+	public void ThemeBrightnessToggle_Renders_DarkButton()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+
+		// Act
+		var cut = Render<ThemeBrightnessToggleComponent>();
+
+		// Assert
+		var darkBtn = cut.Find("#nav-btn-dark");
+		darkBtn.Should().NotBeNull();
+		darkBtn.TextContent.Trim().Should().Contain("Dark");
+	}
+
+	[Fact]
+	public void ThemeBrightnessToggle_LightButton_HasSunEmoji()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+
+		// Act
+		var cut = Render<ThemeBrightnessToggleComponent>();
+
+		// Assert — ☀ present in light button markup
+		cut.Find("#nav-btn-light").TextContent.Should().Contain("☀");
+	}
+
+	[Fact]
+	public void ThemeBrightnessToggle_DarkButton_HasHalfMoonEmoji()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+
+		// Act
+		var cut = Render<ThemeBrightnessToggleComponent>();
+
+		// Assert — ◐ present in dark button markup
+		cut.Find("#nav-btn-dark").TextContent.Should().Contain("◐");
+	}
+
+	[Fact]
+	public void ThemeBrightnessToggle_Buttons_HaveBrightnessButtonClass()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+
+		// Act
+		var cut = Render<ThemeBrightnessToggleComponent>();
+
+		// Assert — both buttons carry .brightness-btn so ThemeManager.syncUI can target them
+		var buttons = cut.FindAll(".brightness-btn");
+		buttons.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public void ThemeBrightnessToggle_Buttons_HaveBtnClass()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+
+		// Act
+		var cut = Render<ThemeBrightnessToggleComponent>();
+
+		// Assert
+		var buttons = cut.FindAll(".btn");
+		buttons.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public void ThemeBrightnessToggle_Container_HasThemeBrightnessToggleClass()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+
+		// Act
+		var cut = Render<ThemeBrightnessToggleComponent>();
+
+		// Assert
+		cut.Find(".theme-brightness-toggle").Should().NotBeNull();
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Test list item 2 — active state synced from persisted localStorage on load
+	// (verified by ThemeManager.syncUI being called on first render)
+	// ──────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task ThemeBrightnessToggle_OnAfterRenderAsync_CallsSyncUI_OnFirstRender()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+
+		// Act
+		var cut = Render<ThemeBrightnessToggleComponent>();
+		await cut.InvokeAsync(() => Task.CompletedTask);
+
+		// Assert — syncUI is what drives the .active class state on the buttons
+		JSInterop.Invocations["ThemeManager.syncUI"].Should()
+			.HaveCount(1, "ThemeManager.syncUI must be called exactly once on first render to reflect persisted brightness");
+	}
+
+	[Fact]
+	public async Task ThemeBrightnessToggle_OnAfterRenderAsync_DoesNotCallSelectBrightness_OnLoad()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+
+		// Act
+		var cut = Render<ThemeBrightnessToggleComponent>();
+		await cut.InvokeAsync(() => Task.CompletedTask);
+
+		// Assert — selectBrightnessAndUpdateUI should NOT fire on init; only syncUI does
+		JSInterop.Invocations
+			.Any(i => i.Identifier == "ThemeManager.selectBrightnessAndUpdateUI")
+			.Should().BeFalse("brightness should not be changed on load, only synced");
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Test list items 1 & 6 — button clicks call the correct JS with correct args
+	// (JS applies theme-*-light / theme-*-dark class to <html> and calls syncUI
+	// on ALL .brightness-btn elements, including those in the full ThemeSelector card)
+	// ──────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task ThemeBrightnessToggle_LightButton_Click_CallsSelectBrightnessAndUpdateUI_WithLightArg()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+		JSInterop.SetupVoid("ThemeManager.selectBrightnessAndUpdateUI", _ => true);
+
+		var cut = Render<ThemeBrightnessToggleComponent>();
+
+		// Act
+		await cut.Find("#nav-btn-light").ClickAsync(new());
+
+		// Assert
+		JSInterop.VerifyInvoke("ThemeManager.selectBrightnessAndUpdateUI");
+		var invocations = JSInterop.Invocations["ThemeManager.selectBrightnessAndUpdateUI"];
+		invocations.Should().HaveCount(1);
+		invocations[0].Arguments[0].Should().Be("light",
+			"clicking the Light button must pass \"light\" so ThemeManager applies the light variant of the current colour family");
+	}
+
+	[Fact]
+	public async Task ThemeBrightnessToggle_DarkButton_Click_CallsSelectBrightnessAndUpdateUI_WithDarkArg()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+		JSInterop.SetupVoid("ThemeManager.selectBrightnessAndUpdateUI", _ => true);
+
+		var cut = Render<ThemeBrightnessToggleComponent>();
+
+		// Act
+		await cut.Find("#nav-btn-dark").ClickAsync(new());
+
+		// Assert
+		JSInterop.VerifyInvoke("ThemeManager.selectBrightnessAndUpdateUI");
+		var invocations = JSInterop.Invocations["ThemeManager.selectBrightnessAndUpdateUI"];
+		invocations.Should().HaveCount(1);
+		invocations[0].Arguments[0].Should().Be("dark",
+			"clicking the Dark button must pass \"dark\" so ThemeManager applies the dark variant of the current colour family");
+	}
+
+	/// <summary>
+	/// Verifies that ThemeManager.syncUI is called only once — on first render —
+	/// not on subsequent re-renders triggered by button clicks.
+	/// </summary>
+	[Fact]
+	public async Task ThemeBrightnessToggle_SyncUI_CalledOnlyOnFirstRender_NotOnSubsequentRenders()
+	{
+		// Arrange
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+		JSInterop.SetupVoid("ThemeManager.selectBrightnessAndUpdateUI", _ => true);
+
+		var cut = Render<ThemeBrightnessToggleComponent>();
+		await cut.InvokeAsync(() => Task.CompletedTask); // allow first render to settle
+
+		// Act — click a button to trigger a re-render cycle
+		await cut.Find("#nav-btn-light").ClickAsync(new());
+
+		// Assert — syncUI was still called exactly once (not again after the click re-render)
+		JSInterop.Invocations["ThemeManager.syncUI"].Should()
+			.HaveCount(1, "ThemeManager.syncUI must not be called again on re-renders — only on first render");
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Test list item 7 — does not conflict with ThemeToggle (both can be rendered)
+	// ──────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void ThemeBrightnessToggle_RendersSuccessfully_WhenNoOtherThemeComponentPresent()
+	{
+		// Arrange & Act — no exception from the component
+		JSInterop.SetupVoid("ThemeManager.syncUI");
+
+		var act = () => Render<ThemeBrightnessToggleComponent>();
+
+		// Assert
+		act.Should().NotThrow();
+	}
+}

--- a/tests/Web.Tests.Unit/Components/Shared/ThemeColorDropdownComponentTests.cs
+++ b/tests/Web.Tests.Unit/Components/Shared/ThemeColorDropdownComponentTests.cs
@@ -1,0 +1,262 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     ThemeColorDropdownComponentTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : ArticlesSite
+// Project Name :  Web.Tests.Unit
+// =======================================================
+
+namespace Web.Components.Shared;
+
+/// <summary>
+/// Unit tests for ThemeColorDropdownComponent using bUnit.
+/// Covers rendering (4 emoji options), on-load pre-selection, and colour-change JS interop.
+///
+/// JS-side effects (HTML class and localStorage update) are verified by asserting the exact
+/// arguments passed to ThemeManager.selectColorAndUpdateUI / ThemeManager.getCurrentColor,
+/// because bUnit does not execute real JavaScript.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class ThemeColorDropdownComponentTests : BunitContext
+{
+	// ──────────────────────────────────────────────────────────────────────────
+	// Rendering
+	// ──────────────────────────────────────────────────────────────────────────
+
+	/// <summary>
+	/// Test list item 9 — component renders a &lt;select&gt; with exactly 4 colour options.
+	/// </summary>
+	[Fact]
+	public void ThemeColorDropdown_Renders_SelectElement()
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+
+		// Act
+		var cut = Render<ThemeColorDropdownComponent>();
+
+		// Assert
+		cut.Find("select").Should().NotBeNull();
+	}
+
+	[Fact]
+	public void ThemeColorDropdown_Renders_ExactlyFourOptions()
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+
+		// Act
+		var cut = Render<ThemeColorDropdownComponent>();
+
+		// Assert
+		cut.FindAll("option").Should().HaveCount(4);
+	}
+
+	[Fact]
+	public void ThemeColorDropdown_Options_HaveCorrectValues()
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+
+		// Act
+		var cut = Render<ThemeColorDropdownComponent>();
+
+		// Assert
+		var options = cut.FindAll("option");
+		options.Select(o => o.GetAttribute("value")).Should()
+			.BeEquivalentTo(["RED", "BLUE", "GREEN", "YELLOW"]);
+	}
+
+	/// <summary>
+	/// Test list decision 2 — options carry emoji colour indicators.
+	/// </summary>
+	[Theory]
+	[InlineData("RED", "🔴")]
+	[InlineData("BLUE", "🔵")]
+	[InlineData("GREEN", "🟢")]
+	[InlineData("YELLOW", "🟡")]
+	public void ThemeColorDropdown_Options_ContainEmojiAndLabel(string value, string expectedEmoji)
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+
+		// Act
+		var cut = Render<ThemeColorDropdownComponent>();
+
+		// Assert
+		var option = cut.Find($"option[value='{value}']");
+		option.TextContent.Should().Contain(expectedEmoji, $"option {value} must show the {expectedEmoji} emoji");
+	}
+
+	[Fact]
+	public void ThemeColorDropdown_Select_HasThemeColorDropdownClass()
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+
+		// Act
+		var cut = Render<ThemeColorDropdownComponent>();
+
+		// Assert
+		cut.Find("select").ClassList.Should().Contain("theme-color-dropdown");
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Test list item 4 — dropdown pre-selects the persisted colour on load
+	// ──────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task ThemeColorDropdown_OnAfterRenderAsync_CallsGetCurrentColor()
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+
+		// Act
+		var cut = Render<ThemeColorDropdownComponent>();
+		await cut.InvokeAsync(() => Task.CompletedTask);
+
+		// Assert
+		JSInterop.Invocations["ThemeManager.getCurrentColor"].Should()
+			.HaveCount(1, "getCurrentColor must be called once on first render to pre-select the persisted colour");
+	}
+
+	[Theory]
+	[InlineData("RED")]
+	[InlineData("BLUE")]
+	[InlineData("GREEN")]
+	[InlineData("YELLOW")]
+	public async Task ThemeColorDropdown_OnAfterRenderAsync_PreSelectsActiveColour(string persistedColor)
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult(persistedColor);
+
+		// Act
+		var cut = Render<ThemeColorDropdownComponent>();
+		await cut.InvokeAsync(() => Task.CompletedTask);
+
+		// Assert — the select value attribute must reflect the persisted colour
+		cut.Find("select").GetAttribute("value").Should().Be(persistedColor,
+			$"the dropdown must pre-select \"{persistedColor}\" to reflect the persisted theme");
+	}
+
+	[Fact]
+	public void ThemeColorDropdown_DefaultSelectedColor_IsBLUE_BeforeFirstRender()
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+
+		// Act — component renders synchronously; JS result not applied until after render
+		var cut = Render<ThemeColorDropdownComponent>();
+
+		// Assert — BLUE is the hard-coded field default
+		cut.Find("select").GetAttribute("value").Should().Be("BLUE");
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Test list items 3 & 5 — changing colour calls selectColorAndUpdateUI
+	// (ThemeManager.selectColorAndUpdateUI updates localStorage["tailwind-color-theme"],
+	// applies the CSS class on <html>, and calls syncUI which updates ALL .color-btn
+	// elements in the DOM — including those in the full ThemeSelector card)
+	// ──────────────────────────────────────────────────────────────────────────
+
+	[Theory]
+	[InlineData("RED")]
+	[InlineData("BLUE")]
+	[InlineData("GREEN")]
+	[InlineData("YELLOW")]
+	public async Task ThemeColorDropdown_OnChange_CallsSelectColorAndUpdateUI_WithCorrectArg(string selectedColor)
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+		JSInterop.SetupVoid("ThemeManager.selectColorAndUpdateUI", _ => true);
+
+		var cut = Render<ThemeColorDropdownComponent>();
+
+		// Act
+		await cut.Find("select").ChangeAsync(new() { Value = selectedColor });
+
+		// Assert
+		JSInterop.VerifyInvoke("ThemeManager.selectColorAndUpdateUI");
+		var invocations = JSInterop.Invocations["ThemeManager.selectColorAndUpdateUI"];
+		invocations.Should().HaveCount(1);
+		invocations[0].Arguments[0].Should().Be(selectedColor,
+			$"selecting \"{selectedColor}\" must pass exactly \"{selectedColor}\" to ThemeManager, " +
+			"preserving the current brightness and updating localStorage + html class + all .color-btn active states");
+	}
+
+	/// <summary>
+	/// Verifies that ThemeManager.getCurrentColor is called only once — on first render —
+	/// not again when the user changes the dropdown selection.
+	/// </summary>
+	[Fact]
+	public async Task ThemeColorDropdown_GetCurrentColor_CalledOnlyOnFirstRender_NotOnSubsequentChanges()
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+		JSInterop.SetupVoid("ThemeManager.selectColorAndUpdateUI", _ => true);
+
+		var cut = Render<ThemeColorDropdownComponent>();
+		await cut.InvokeAsync(() => Task.CompletedTask); // allow first render to settle
+
+		// Act — change the dropdown to trigger a re-render cycle
+		await cut.Find("select").ChangeAsync(new() { Value = "RED" });
+
+		// Assert — getCurrentColor was still called exactly once
+		JSInterop.Invocations["ThemeManager.getCurrentColor"].Should()
+			.HaveCount(1, "ThemeManager.getCurrentColor must not be called again after the initial load");
+	}
+
+	[Fact]
+	public async Task ThemeColorDropdown_OnChange_DoesNotCallSelectBrightness()
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+		JSInterop.SetupVoid("ThemeManager.selectColorAndUpdateUI", _ => true);
+
+		var cut = Render<ThemeColorDropdownComponent>();
+
+		// Act
+		await cut.Find("select").ChangeAsync(new() { Value = "RED" });
+
+		// Assert — colour change must not alter brightness
+		JSInterop.Invocations
+			.Any(i => i.Identifier == "ThemeManager.selectBrightnessAndUpdateUI")
+			.Should().BeFalse("changing colour must preserve brightness — selectBrightnessAndUpdateUI should not be called");
+	}
+
+	[Fact]
+	public async Task ThemeColorDropdown_OnChange_WithNullValue_DefaultsToBLUE()
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+		JSInterop.SetupVoid("ThemeManager.selectColorAndUpdateUI", _ => true);
+
+		var cut = Render<ThemeColorDropdownComponent>();
+
+		// Act — simulate a null value coming through ChangeEventArgs
+		await cut.Find("select").ChangeAsync(new() { Value = null });
+
+		// Assert — null value falls back to BLUE via the null-coalescing operator
+		var invocations = JSInterop.Invocations["ThemeManager.selectColorAndUpdateUI"];
+		invocations.Should().HaveCount(1);
+		invocations[0].Arguments[0].Should().Be("BLUE");
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Test list item 7 — renders successfully without conflicting with other components
+	// ──────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void ThemeColorDropdown_RendersSuccessfully_WhenNoOtherThemeComponentPresent()
+	{
+		// Arrange
+		JSInterop.Setup<string>("ThemeManager.getCurrentColor").SetResult("BLUE");
+
+		// Act
+		var act = () => Render<ThemeColorDropdownComponent>();
+
+		// Assert
+		act.Should().NotThrow();
+	}
+}

--- a/tests/Web.Tests.Unit/Data/MongoDbServiceExtensionsTests.cs
+++ b/tests/Web.Tests.Unit/Data/MongoDbServiceExtensionsTests.cs
@@ -27,6 +27,9 @@ public class MongoDbServiceExtensionsTests
 		File.WriteAllText(Path.Combine(tempDir, "appsettings.json"), json);
 
 		var builder = WebApplication.CreateBuilder(new WebApplicationOptions { ContentRootPath = tempDir });
+		// Override CI env vars (e.g. empty MongoDB__ConnectionString) — indexer assignment wins over env vars
+		builder.Configuration["MongoDb:ConnectionString"] = "mongodb://host:27021";
+		builder.Configuration["MongoDb:Database"] = "TestDb";
 
 		// Act
 		builder.AddMongoDb();
@@ -104,6 +107,8 @@ public class MongoDbServiceExtensionsTests
 			Environment.SetEnvironmentVariable("MONGODB_DATABASE_NAME", null);
 
 			var builder = WebApplication.CreateBuilder(new WebApplicationOptions { ContentRootPath = tempDir });
+			// Override CI env vars (e.g. empty MongoDB__ConnectionString) — indexer assignment wins over env vars
+			builder.Configuration["MongoDb:ConnectionString"] = "mongodb://host:27023";
 			builder.AddMongoDb();
 
 			using var sp = builder.Services.BuildServiceProvider();


### PR DESCRIPTION
## Summary

Splits the existing `ThemeSelector.razor` full-card into two compact, nav-friendly Blazor components that sit in the navigation bar on `sm+` breakpoints. The full `ThemeSelector` card is **unchanged** — it continues to work on the settings page.

---

## New Components

### `ThemeBrightnessToggleComponent.razor`
- Two buttons — **☀ Light** and **◐ Dark**
- Carries `.brightness-btn` class so `ThemeManager.syncUI()` updates the active state in sync with the full ThemeSelector card
- Calls `ThemeManager.selectBrightnessAndUpdateUI()` on click

### `ThemeColorDropdownComponent.razor`
- `<select>` dropdown with emoji colour indicators: 🔴 Red · 🔵 Blue · 🟢 Green · 🟡 Yellow
- Reads persisted colour on load via `ThemeManager.getCurrentColor()`
- Calls `ThemeManager.selectColorAndUpdateUI()` on change (preserves current brightness)

---

## Nav Integration

`NavMenuComponent.razor` updated:

```razor
<div class="hidden sm:flex items-center gap-2">
    <ThemeBrightnessToggleComponent />
    <ThemeColorDropdownComponent />
</div>
```

- Hidden on mobile (`sm:hidden` matching nav links breakpoint)
- All three components share `window.ThemeManager` — state is always consistent across the nav controls and the full settings card

---

## CSS (`input.css`)

Two new component-scoped classes added to `@layer components`:

| Class | Purpose |
|---|---|
| `.theme-brightness-toggle` | Flex wrapper for the two brightness buttons |
| `.theme-color-dropdown` | Rounded `<select>` styled to match the nav palette |

---

## Tests — 47 new, all passing ✅

| File | Tests |
|---|---|
| `ThemeBrightnessToggleComponentTests.cs` | 15 |
| `ThemeColorDropdownComponentTests.cs` | 23 |
| `NavMenuComponentTests.cs` | 9 |

**Coverage includes:**
- Correct rendering (2 buttons, 4 options, emoji, IDs, CSS classes)
- `syncUI` called on first render only (not on subsequent re-renders)
- `getCurrentColor` called on first render, pre-selects active colour (Theory × 4)
- Light/Dark click each pass the correct string to `selectBrightnessAndUpdateUI`
- All 4 colour changes pass the correct string to `selectColorAndUpdateUI` (Theory × 4)
- Nav wrapper has `hidden sm:flex items-center gap-2`
- Both components rendered inside the same mobile-hidden wrapper
- Cross-component: nav colour change calls the same JS function as ThemeSelector
- Cross-component: nav brightness change calls the same JS function as ThemeSelector

---

## What's Not Changed

- `ThemeSelector.razor` — untouched, full card still works
- `ThemeToggle.razor` — untouched, dark-mode toggle still works
- `theme-manager.js` — no changes, no new JavaScript needed

---

## Confirmed Decisions

1. ✅ Hidden on mobile — `hidden sm:flex` matches nav link breakpoint
2. ✅ Emoji colour indicators in dropdown
3. ✅ `ThemeManager.syncUI()` updates both nav buttons and ThemeSelector card simultaneously
4. ✅ `ThemeSelector.razor` to be retired once these components are proven in production
