### PR TITLE
chore: sync squad workflows from dotfiles

### DIFF
--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -3,7 +3,7 @@ name: Squad Heartbeat (Ralph)
 on:
   schedule:
     # Proactive polling every 30 minutes
-    - cron: '*/30 * * * *'
+    - cron: '*/15 * * * *'
 
   # React to completed work or new squad work
   issues:

--- a/.github/workflows/squad-pr-auto-label.yml
+++ b/.github/workflows/squad-pr-auto-label.yml
@@ -1,0 +1,94 @@
+---
+name: Squad PR Auto-Label
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-label PR for squad system
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+
+            // Fetch current labels on the PR
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number
+            });
+
+            const labelNames = currentLabels.map(l => l.name);
+
+            // Check if already has squad labels
+            const hasSquadLabel = labelNames.some(name => 
+              name === 'squad' || name.startsWith('squad:')
+            );
+
+            if (hasSquadLabel) {
+              core.info(`PR #${pr.number} already has squad label(s) — skipping`);
+              return;
+            }
+
+            let labelsToAdd = [];
+            let commentBody = '';
+
+            // Handle known automation bots
+            const knownBots = ['dependabot[bot]', 'renovate[bot]', 'github-actions[bot]'];
+            if (knownBots.includes(author)) {
+              labelsToAdd = ['squad:boromir', 'squad'];
+              commentBody = [
+                `### 🤖 Dependency Update PR`,
+                '',
+                `This PR was opened by **${author}** and has been automatically labeled for **Boromir** (DevOps) to review.`,
+                '',
+                `**Labels applied:**`,
+                `- \`squad:boromir\` — Assigned to DevOps for dependency updates`,
+                `- \`squad\` — In triage queue`,
+                '',
+                `> Dependency and infrastructure updates are owned by the DevOps team.`
+              ].join('\n');
+            } else {
+              // Handle general PRs without squad labels
+              labelsToAdd = ['squad'];
+              commentBody = [
+                `### 🏗️ PR Added to Squad Triage Queue`,
+                '',
+                `This PR has been labeled with \`squad\` and added to the triage queue.`,
+                '',
+                `**Next steps:**`,
+                `- The squad Lead will review and assign to an appropriate team member`,
+                `- A \`squad:member\` label will be added after triage`,
+                '',
+                `> If you know which squad member should handle this, you can add the appropriate \`squad:member\` label yourself.`
+              ].join('\n');
+            }
+
+            // Add labels
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: labelsToAdd
+            });
+
+            core.info(`Added labels to PR #${pr.number}: ${labelsToAdd.join(', ')}`);
+
+            // Post comment
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: commentBody
+            });
+
+            core.info(`Posted auto-label comment on PR #${pr.number}`);


### PR DESCRIPTION
## Summary

- Add `squad-pr-auto-label.yml`: automatically labels PRs based on the branch author and squad member routing
- Update `squad-heartbeat.yml`: reduce cron schedule from 30 to 15 minutes for faster triage

## Changes

| File | Change |
|------|--------|
| `.github/workflows/squad-pr-auto-label.yml` | New — auto-labels PRs for squad routing |
| `.github/workflows/squad-heartbeat.yml` | Update cron: 30min → 15min |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>